### PR TITLE
[Update-Create-Org] Update CreateOrganisationConfig

### DIFF
--- a/data/pg/commonMuktaUiConfig/CreateOrganizationConfig.json
+++ b/data/pg/commonMuktaUiConfig/CreateOrganizationConfig.json
@@ -511,7 +511,7 @@
                 "withoutLabel": true,
                 "key": "taxIdentifier",
                 "customProps" : {
-                  "isMandatory": true
+                  "isMandatory": false
                 }
               }
             ]


### PR DESCRIPTION
Set Tax Identifiers as not mandatory in Create Organisation Config.